### PR TITLE
Feat/#15

### DIFF
--- a/userservice/build.gradle
+++ b/userservice/build.gradle
@@ -27,6 +27,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
+
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6' // or 'io.jsonwebtoken:jjwt-gson:0.12.6' for gson

--- a/userservice/src/main/java/com/bjcareer/userservice/UserserviceApplication.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/UserserviceApplication.java
@@ -3,9 +3,11 @@ package com.bjcareer.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class UserserviceApplication {
 
 	public static void main(String[] args) {

--- a/userservice/src/main/java/com/bjcareer/userservice/application/auth/LoginService.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/application/auth/LoginService.java
@@ -2,6 +2,7 @@ package com.bjcareer.userservice.application.auth;
 
 import java.util.Optional;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +11,7 @@ import com.bjcareer.userservice.application.ports.in.LoginCommand;
 import com.bjcareer.userservice.application.ports.in.LoginUsecase;
 import com.bjcareer.userservice.application.ports.in.TokenUsecase;
 import com.bjcareer.userservice.application.ports.out.LoadUserPort;
+import com.bjcareer.userservice.application.ports.out.message.UserLoggedInRecorderEvent;
 import com.bjcareer.userservice.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class LoginService implements LoginUsecase {
 	private final LoadUserPort loadUserPort;
 	private final TokenUsecase tokenUsecase;
+	private final ApplicationEventPublisher publisher;
 
 	@Transactional(readOnly = true)
 	public User login(LoginCommand command) {
@@ -40,7 +43,9 @@ public class LoginService implements LoginUsecase {
 			throw new UnauthorizedAccessAttemptException("잘못된 ID나 PASSWORD를 입력했습니다2.");
 		}
 
+		publisher.publishEvent(new UserLoggedInRecorderEvent(storedUser));
 		tokenUsecase.generateJWT(storedUser);
+
 		return storedUser;
 	}
 }

--- a/userservice/src/main/java/com/bjcareer/userservice/application/message/UserLoggedInRecorderEventHandler.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/application/message/UserLoggedInRecorderEventHandler.java
@@ -1,0 +1,39 @@
+package com.bjcareer.userservice.application.message;
+
+import java.time.LocalDate;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.userservice.application.ports.out.PersistActiveUserPort;
+import com.bjcareer.userservice.application.ports.out.message.UserLoggedInRecorderEvent;
+import com.bjcareer.userservice.domain.entity.UserActive;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserLoggedInRecorderEventHandler {
+	private final PersistActiveUserPort persistActiveUserPort;
+
+	@EventListener
+	@Async
+	@Transactional
+	public void handle(UserLoggedInRecorderEvent event) {
+		LocalDate localDate = LocalDate.now();
+		// 유저가 해당 날짜에 로그인 기록이 없을 때만 새로운 기록 추가
+		UserActive userActive1 = persistActiveUserPort.findUserByLocaleDate(event.getUser(), localDate)
+			.orElseGet(() -> {
+				UserActive userActive = new UserActive(event.getUser());
+				persistActiveUserPort.persistActiveUser(userActive);
+				return userActive;
+			});
+
+		// 유저가 해당 날짜에 로그인 기록이 있을 때는 기존 기록 업데이트
+		log.debug("userActive1 = " + userActive1);
+	}
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/PersistActiveUserPort.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/PersistActiveUserPort.java
@@ -1,0 +1,13 @@
+package com.bjcareer.userservice.application.ports.out;
+
+import java.time.LocalDate;
+import java.util.Locale;
+import java.util.Optional;
+
+import com.bjcareer.userservice.domain.entity.User;
+import com.bjcareer.userservice.domain.entity.UserActive;
+
+public interface PersistActiveUserPort {
+	void persistActiveUser(UserActive userActive);
+	Optional<UserActive> findUserByLocaleDate(User user, LocalDate localDate);
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/PersistActiveUserPort.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/PersistActiveUserPort.java
@@ -1,6 +1,7 @@
 package com.bjcareer.userservice.application.ports.out;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -10,4 +11,5 @@ import com.bjcareer.userservice.domain.entity.UserActive;
 public interface PersistActiveUserPort {
 	void persistActiveUser(UserActive userActive);
 	Optional<UserActive> findUserByLocaleDate(User user, LocalDate localDate);
+	List<UserActive> findDailyActiveUsers(LocalDate localDate);
 }

--- a/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/message/UserLoggedInRecorderEvent.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/application/ports/out/message/UserLoggedInRecorderEvent.java
@@ -1,0 +1,14 @@
+package com.bjcareer.userservice.application.ports.out.message;
+
+import com.bjcareer.userservice.domain.entity.User;
+
+import lombok.Getter;
+
+@Getter
+public class UserLoggedInRecorderEvent {
+	private User user;
+
+	public UserLoggedInRecorderEvent(User user) {
+		this.user = user;
+	}
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/RandomCodeGenerator.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/RandomCodeGenerator.java
@@ -1,8 +1,8 @@
 package com.bjcareer.userservice.domain;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.Random;
+
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RandomCodeGenerator {

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/Redis.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/Redis.java
@@ -1,14 +1,13 @@
 package com.bjcareer.userservice.domain;
 
-import jakarta.persistence.Entity;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.concurrent.TimeUnit;
+
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
-import java.util.concurrent.TimeUnit;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 
 @Data

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/entity/Role.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/entity/Role.java
@@ -1,13 +1,19 @@
 package com.bjcareer.userservice.domain.entity;
 
+import java.util.List;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/entity/RoleAssignments.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/entity/RoleAssignments.java
@@ -1,7 +1,11 @@
 package com.bjcareer.userservice.domain.entity;
 
-
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/entity/RoleType.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/entity/RoleType.java
@@ -1,7 +1,5 @@
 package com.bjcareer.userservice.domain.entity;
 
-import java.io.Serializable;
-
 public enum RoleType {
     ALL("All User asscess"),
     ADMIN("Administrator with full access"),

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/entity/User.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/entity/User.java
@@ -50,6 +50,9 @@ public class User {
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<RoleAssignments> assignments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<UserActive> userActives = new ArrayList<>();
+
     @Version
     private Long version;
 

--- a/userservice/src/main/java/com/bjcareer/userservice/domain/entity/UserActive.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/domain/entity/UserActive.java
@@ -1,0 +1,40 @@
+package com.bjcareer.userservice.domain.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	name = "user_active",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"user_id", "lastLogin"})
+	}
+)
+public class UserActive {
+	@Id
+	@GeneratedValue
+	private Long id;
+	private LocalDate lastLogin;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public UserActive(User user) {
+		this.user = user;
+		lastLogin = LocalDateTime.now().toLocalDate();
+	}
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/out/persistance/UserRecordRepository.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/out/persistance/UserRecordRepository.java
@@ -1,0 +1,29 @@
+package com.bjcareer.userservice.out.persistance;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.bjcareer.userservice.application.ports.out.PersistActiveUserPort;
+import com.bjcareer.userservice.domain.entity.User;
+import com.bjcareer.userservice.domain.entity.UserActive;
+import com.bjcareer.userservice.out.persistance.repository.ActiveUserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRecordRepository implements PersistActiveUserPort {
+	private final ActiveUserRepository repository;
+
+	@Override
+	public void persistActiveUser(UserActive userActive) {
+		repository.save(userActive);
+	}
+
+	@Override
+	public Optional<UserActive> findUserByLocaleDate(User user, LocalDate localDate) {
+		return repository.findByUserInLocalDate(user, localDate);
+	}
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/out/persistance/UserRecordRepository.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/out/persistance/UserRecordRepository.java
@@ -1,6 +1,7 @@
 package com.bjcareer.userservice.out.persistance;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -25,5 +26,10 @@ public class UserRecordRepository implements PersistActiveUserPort {
 	@Override
 	public Optional<UserActive> findUserByLocaleDate(User user, LocalDate localDate) {
 		return repository.findByUserInLocalDate(user, localDate);
+	}
+
+	@Override
+	public List<UserActive> findDailyActiveUsers(LocalDate localDate) {
+		return repository.findDailyActiveUsers(localDate);
 	}
 }

--- a/userservice/src/main/java/com/bjcareer/userservice/out/persistance/repository/ActiveUserRepository.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/out/persistance/repository/ActiveUserRepository.java
@@ -1,6 +1,7 @@
 package com.bjcareer.userservice.out.persistance.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,7 @@ import com.bjcareer.userservice.domain.entity.UserActive;
 public interface ActiveUserRepository extends CrudRepository<UserActive, Long> {
 	@Query("SELECT u FROM UserActive u WHERE u.user = :user AND u.lastLogin = :localDate")
 	Optional<UserActive> findByUserInLocalDate(@Param("user") User user, @Param("localDate") LocalDate localDate);
+
+	@Query("SELECT u FROM UserActive u WHERE u.lastLogin = :localDate")
+	List<UserActive> findDailyActiveUsers(@Param("localDate") LocalDate localDate);
 }

--- a/userservice/src/main/java/com/bjcareer/userservice/out/persistance/repository/ActiveUserRepository.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/out/persistance/repository/ActiveUserRepository.java
@@ -1,0 +1,16 @@
+package com.bjcareer.userservice.out.persistance.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.bjcareer.userservice.domain.entity.User;
+import com.bjcareer.userservice.domain.entity.UserActive;
+
+public interface ActiveUserRepository extends CrudRepository<UserActive, Long> {
+	@Query("SELECT u FROM UserActive u WHERE u.user = :user AND u.lastLogin = :localDate")
+	Optional<UserActive> findByUserInLocalDate(@Param("user") User user, @Param("localDate") LocalDate localDate);
+}

--- a/userservice/src/main/java/com/bjcareer/userservice/out/prometheus/DauServiceAdapter.java
+++ b/userservice/src/main/java/com/bjcareer/userservice/out/prometheus/DauServiceAdapter.java
@@ -1,0 +1,28 @@
+package com.bjcareer.userservice.out.prometheus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.bjcareer.userservice.application.ports.out.PersistActiveUserPort;
+import com.bjcareer.userservice.domain.entity.UserActive;
+import com.bjcareer.userservice.out.persistance.repository.ActiveUserRepository;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DauServiceAdapter {
+	private final MeterRegistry meterRegistry;
+	private final PersistActiveUserPort activeUserPort;
+
+	// 하루에 한 번 DAU 값을 갱신하는 스케줄러
+	@Scheduled(fixedRate = 3600000)
+	public void calculateDAU() {
+		List<UserActive> dailyActiveUsers = activeUserPort.findDailyActiveUsers(LocalDate.now());
+		meterRegistry.gauge("dau_metric", dailyActiveUsers.size());
+	}
+}

--- a/userservice/src/main/resources/application-dev.yml
+++ b/userservice/src/main/resources/application-dev.yml
@@ -52,3 +52,8 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus  # Prometheus 메트릭 엔드포인트만 개방

--- a/userservice/src/main/resources/application.yml
+++ b/userservice/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -46,4 +46,8 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
 
-
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*" # Expose all endpoints

--- a/userservice/src/test/java/com/bjcareer/userservice/domain/entity/UserActiveTest.java
+++ b/userservice/src/test/java/com/bjcareer/userservice/domain/entity/UserActiveTest.java
@@ -1,0 +1,33 @@
+package com.bjcareer.userservice.domain.entity;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.userservice.commonTest.UsecaseTest;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@UsecaseTest
+@SpringBootTest
+class UserActiveTest {
+	@PersistenceContext
+	private EntityManager em;
+
+
+	@Test
+	@Transactional
+	void test() {
+		User user = new User("test@test.com", "test");
+		em.persist(user);
+
+		UserActive userActive = new UserActive(user);
+		em.persist(userActive);
+
+		em.flush();
+		em.clear();
+
+		System.out.println("userActive = " + userActive.getLastLogin());
+	}
+}

--- a/userservice/src/test/java/com/bjcareer/userservice/out/persistance/UserRecordRepositoryTest.java
+++ b/userservice/src/test/java/com/bjcareer/userservice/out/persistance/UserRecordRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.bjcareer.userservice.out.persistance;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.userservice.commonTest.UsecaseTest;
+import com.bjcareer.userservice.domain.entity.User;
+import com.bjcareer.userservice.domain.entity.UserActive;
+import com.bjcareer.userservice.out.persistance.repository.ActiveUserRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@UsecaseTest
+@SpringBootTest
+@Transactional
+class UserRecordRepositoryTest {
+	@Autowired
+	ActiveUserRepository activeUserRepository;
+
+	@PersistenceContext
+	private EntityManager em;
+
+	@Test
+	@Transactional(readOnly = false)
+	void test() {
+		User user = createUser();
+
+		UserActive userActive = new UserActive(user);
+		activeUserRepository.save(userActive);
+
+
+		LocalDate localDate = LocalDate.now();
+		UserActive userActive2 = activeUserRepository.findByUserInLocalDate(user, localDate).get();
+
+		assertNotNull(userActive2);
+	}
+
+	private User createUser() {
+		User user = new User("test@test.com", "password");
+		em.persist(user);
+		em.flush();
+		em.clear();
+		return user;
+	}
+}

--- a/userservice/src/test/java/com/bjcareer/userservice/out/persistance/UserRecordRepositoryTest.java
+++ b/userservice/src/test/java/com/bjcareer/userservice/out/persistance/UserRecordRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,7 +31,7 @@ class UserRecordRepositoryTest {
 
 	@Test
 	@Transactional(readOnly = false)
-	void test() {
+	void 일간사용자저장() {
 		User user = createUser();
 
 		UserActive userActive = new UserActive(user);
@@ -41,6 +42,13 @@ class UserRecordRepositoryTest {
 		UserActive userActive2 = activeUserRepository.findByUserInLocalDate(user, localDate).get();
 
 		assertNotNull(userActive2);
+	}
+
+	@Test
+	@Transactional()
+	void 저장된_일간_사용자가_없을떄() {
+		List<UserActive> dailyActiveUsers = activeUserRepository.findDailyActiveUsers(LocalDate.now());
+		assertEquals(0, dailyActiveUsers.size());
 	}
 
 	private User createUser() {


### PR DESCRIPTION
## 💡 요약 (Summary)
DAU(일일 활성 사용자)를 추적하기 위해 필요한 테이블 설계 및 Prometheus 메트릭을 설정하였습니다. 현재는 한시간 간격으로 추적하지만 사용자가 많아진다면 하루 간격으로 추적하도록 설정 예정임

## 📝 작업 내용 (What was changed)
- [x] dau 추적을 위한 테이블 설계
- [x] dau 추적을 위한 프로메테우스 메트릭 오픈

## 🔗 관련 이슈 (Related Issue)
이 PR과 관련된 이슈 번호를 링크해주세요.  
예시: feat#15

## 📊 변경 이유 (Reason for changes)
서비스 사용 현황을 추적하고, 몇 명의 사용자가 매일 서비스를 사용하고 있는지 파악하기 위해 DAU(일일 활성 사용자) 추적 기능을 도입했습니다.

## 🧪 테스트 (Test)
- [x] 로그인시 Active user 테이블에 값이 기록되는지
- [x] 당일 접속한 사용자 목록을 불러오는지

## 📷 스크린샷 (Screenshots)
<img width="900" alt="스크린샷 2024-10-04 오전 1 58 29" src="https://github.com/user-attachments/assets/c403e703-1b24-4cef-bf16-3d425f7e5575">
