### PR TITLE
feat: Add outbox for coupon message

### DIFF
--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/ParticipationDomain.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/ParticipationDomain.java
@@ -1,18 +1,31 @@
 package com.bjcareer.stockservice.timeDeal.domain;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-@RequiredArgsConstructor
 @Getter
 @ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ParticipationDomain {
-	private final String clientId;
-	private final String sessionId;
+	private String clientId;
+	private String sessionId;
+
+	private boolean result;
 	private Long participationIndex;
+
+	public ParticipationDomain(String clientId, String sessionId) {
+		this.clientId = clientId;
+		this.sessionId = sessionId;
+	}
 
 	public void addParticipationIndex(Long participationIndex) {
 		this.participationIndex = participationIndex;
 	}
+
+	public void setResult(boolean result) {
+		this.result = result;
+	}
+
 }

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCoupon.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCoupon.java
@@ -1,0 +1,31 @@
+package com.bjcareer.stockservice.timeDeal.domain.coupon;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OutboxCoupon {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "json")
+	private String payload; //json
+	private boolean isDelivered;
+
+	public OutboxCoupon(String payload, boolean isDelivered) {
+		this.payload = payload;
+		this.isDelivered = isDelivered;
+	}
+}

--- a/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCouponTest.java
+++ b/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCouponTest.java
@@ -1,0 +1,56 @@
+package com.bjcareer.stockservice.timeDeal.domain.coupon;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.stockservice.timeDeal.domain.ParticipationDomain;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+class OutboxCouponTest {
+	public static final String CLIENT_ID = "test";
+	public static final String SESSION_ID = "test";
+	@Autowired EntityManager em;
+
+	ParticipationDomain participation;
+	@BeforeEach
+	void setUp() {
+		participation = new ParticipationDomain(CLIENT_ID, SESSION_ID);
+	}
+
+	@Test
+	@Transactional
+	void outbox_message_저장_테스트() throws JsonProcessingException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		String payload = objectMapper.writeValueAsString(participation);
+		OutboxCoupon outboxCoupon = new OutboxCoupon(payload, false);
+		em.persist(outboxCoupon);
+		assertNotNull(outboxCoupon.getId());
+	}
+
+	@Test
+	@Transactional
+	void outbox_message_조회_테스트() throws JsonProcessingException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		String payload = objectMapper.writeValueAsString(participation);
+		OutboxCoupon outboxCoupon = new OutboxCoupon(payload, false);
+		em.persist(outboxCoupon);
+
+		OutboxCoupon outboxCoupon1 = em.find(OutboxCoupon.class, outboxCoupon.getId());
+		ParticipationDomain participationDomain = objectMapper.readValue(outboxCoupon1.getPayload(),
+			ParticipationDomain.class);
+		System.out.println(outboxCoupon.getPayload());
+
+		assertEquals("test", participationDomain.getClientId());
+		assertEquals("test", participationDomain.getSessionId());
+	}
+
+}

--- a/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/TimeDealServiceTest.java
+++ b/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/TimeDealServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.mockito.MockitoAnnotations;
 import com.bjcareer.stockservice.timeDeal.application.ports.TimeDealService;
 import com.bjcareer.stockservice.timeDeal.application.ports.in.CreateEventCommand;
 import com.bjcareer.stockservice.timeDeal.application.ports.out.LoadUserPort;
+import com.bjcareer.stockservice.timeDeal.domain.ParticipationDomain;
 import com.bjcareer.stockservice.timeDeal.domain.coupon.Coupon;
 import com.bjcareer.stockservice.timeDeal.domain.event.Event;
 import com.bjcareer.stockservice.timeDeal.domain.event.exception.InvalidEventException;
@@ -97,7 +99,7 @@ public class TimeDealServiceTest {
     void bulkGenerateCoupon_ShouldGenerateCouponsForClients() {
         // Arrange
         Long eventId = 1L;
-        List<String> clients = Arrays.asList("client1", "client2");
+        List<ParticipationDomain> clients = Arrays.asList(new ParticipationDomain("client1", UUID.randomUUID().toString()), new ParticipationDomain("client1", UUID.randomUUID().toString()));
         Event event = mock(Event.class);
 
         when(inMemoryEventRepository.findById(anyLong())).thenReturn(Optional.of(event));


### PR DESCRIPTION
## 💡 요약 (Summary)
Coupon 메세지 발행을 위한 Outbox테이블 설계 

## 📝 작업 내용 (What was changed)
- [x] 아웃박스 테이블 설계

## 🔗 관련 이슈 (Related Issue)
#45 

## 📊 변경 이유 (Reason for changes)
디비와 메세지를 한 트랜잭션에 묶기 위함

## 🧪 테스트 (Test)
이 변경 사항이 잘 동작하는지 확인하기 위해 어떤 테스트가 이루어졌는지 설명해주세요.  
또한, 테스트 결과가 있다면 공유해주세요.

- [x] Outbox 테이블 저장 
- [x] Outbox 테이블 Read 후 payload 검증
