### PR TITLE
Feat/#47

### DIFF
--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/OutboxService.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/OutboxService.java
@@ -1,0 +1,56 @@
+package com.bjcareer.stockservice.timeDeal.application.ports;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.bjcareer.stockservice.TopicConfig;
+import com.bjcareer.stockservice.timeDeal.application.ports.out.OutboxCouponPort;
+import com.bjcareer.stockservice.timeDeal.domain.ParticipationDomain;
+import com.bjcareer.stockservice.timeDeal.domain.coupon.OutboxCoupon;
+import com.bjcareer.stockservice.timeDeal.service.out.CouponMessageCommand;
+import com.bjcareer.stockservice.timeDeal.service.out.MessagePort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxService {
+	private final OutboxCouponPort port;
+	private final MessagePort messagePort;
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	private final String failMessage = "쿠폰 발급에 실패했습니다";
+	private final String successMessage = "쿠폰 발급에 성공했습니다";
+
+	@Scheduled(fixedRate = 3000)
+	@Transactional(rollbackFor = JsonProcessingException.class)
+	public void processOutboxMessage() throws JsonProcessingException {
+		List<OutboxCoupon> load = port.load();
+
+		if (load == null) {
+			log.debug("발행할 메세지가 없습니다.");
+		}
+		log.debug("Outbox message loaded: {}", load);
+
+		for (OutboxCoupon outboxCoupon : load) {
+			ParticipationDomain participationDomain = mapper.readValue(outboxCoupon.getPayload(),
+				ParticipationDomain.class);
+
+			messagePort.sendCouponMessage(TopicConfig.COUPON_TOPIC,
+				new CouponMessageCommand(participationDomain.getSessionId(), participationDomain.isResult(),
+					participationDomain.isResult() ? successMessage : failMessage));
+
+			outboxCoupon.delivered();
+		}
+
+		port.saveAll(load);
+		log.debug("Outbox message processed: {}", load);
+	}
+}

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/TimeDealService.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/TimeDealService.java
@@ -137,10 +137,12 @@ public class TimeDealService implements CreateEventUsecase, CouponUsecase {
                 client.getClientId());
 
             if (byEventIdAndUserId.isPresent()) {
+                client.setResult(false);
                 log.debug("The user has already participated. No additional coupons can be issued");
                 return;
             }
 
+            client.setResult(true);
             coupons.add(new Coupon(event, client.getClientId()));
         });
 

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/out/OutboxCouponPort.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/application/ports/out/OutboxCouponPort.java
@@ -1,0 +1,11 @@
+package com.bjcareer.stockservice.timeDeal.application.ports.out;
+
+import java.util.List;
+
+import com.bjcareer.stockservice.timeDeal.domain.coupon.OutboxCoupon;
+
+public interface OutboxCouponPort {
+	List<OutboxCoupon> load();
+
+	void saveAll(List<OutboxCoupon> outboxCoupons);
+}

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/ParticipationDomain.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/ParticipationDomain.java
@@ -12,7 +12,7 @@ public class ParticipationDomain {
 	private String clientId;
 	private String sessionId;
 
-	private boolean result;
+	private boolean result = false;
 	private Long participationIndex;
 
 	public ParticipationDomain(String clientId, String sessionId) {

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCoupon.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/domain/coupon/OutboxCoupon.java
@@ -28,4 +28,8 @@ public class OutboxCoupon {
 		this.payload = payload;
 		this.isDelivered = isDelivered;
 	}
+
+	public void delivered() {
+		this.isDelivered = true;
+	}
 }

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/out/persistence/OutBoxCouponPortAdapter.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/out/persistence/OutBoxCouponPortAdapter.java
@@ -1,0 +1,26 @@
+package com.bjcareer.stockservice.timeDeal.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.bjcareer.stockservice.timeDeal.application.ports.out.OutboxCouponPort;
+import com.bjcareer.stockservice.timeDeal.domain.coupon.OutboxCoupon;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class OutBoxCouponPortAdapter implements OutboxCouponPort {
+	private final OutBoxCouponRepository outBoxCouponRepository;
+
+	@Override
+	public List<OutboxCoupon> load() {
+		return outBoxCouponRepository.findIsNotDelivered();
+	}
+
+	@Override
+	public void saveAll(List<OutboxCoupon> outboxCoupons) {
+		outBoxCouponRepository.saveAll(outboxCoupons);
+	}
+}

--- a/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/out/persistence/OutBoxCouponRepository.java
+++ b/timeDeal/src/main/java/com/bjcareer/stockservice/timeDeal/out/persistence/OutBoxCouponRepository.java
@@ -1,0 +1,13 @@
+package com.bjcareer.stockservice.timeDeal.out.persistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.bjcareer.stockservice.timeDeal.domain.coupon.OutboxCoupon;
+
+public interface OutBoxCouponRepository extends JpaRepository<OutboxCoupon, Long> {
+	@Query("SELECT o FROM OutboxCoupon as o WHERE o.isDelivered = false")
+	List<OutboxCoupon> findIsNotDelivered();
+}

--- a/timeDeal/src/main/resources/application-dev.yml
+++ b/timeDeal/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/timeDeal/src/main/resources/application.yml
+++ b/timeDeal/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     url: jdbc:postgresql://localhost:5432/stock_service
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true

--- a/timeDeal/src/main/resources/application.yml
+++ b/timeDeal/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
 
   kafka:
     bootstrap-servers: localhost:9092
+
 logging:
   level:
     org.hibernate.SQL: info

--- a/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/application/ports/OutboxServiceTest.java
+++ b/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/application/ports/OutboxServiceTest.java
@@ -1,0 +1,97 @@
+package com.bjcareer.stockservice.timeDeal.application.ports;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.bjcareer.stockservice.TopicConfig;
+import com.bjcareer.stockservice.timeDeal.application.ports.out.OutboxCouponPort;
+import com.bjcareer.stockservice.timeDeal.domain.ParticipationDomain;
+import com.bjcareer.stockservice.timeDeal.domain.coupon.OutboxCoupon;
+import com.bjcareer.stockservice.timeDeal.service.out.CouponMessageCommand;
+import com.bjcareer.stockservice.timeDeal.service.out.MessagePort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxServiceTest {
+
+	@Mock
+	private OutboxCouponPort port;
+
+	@Mock
+	private MessagePort messagePort;
+
+	@InjectMocks
+	private OutboxService outboxService;
+
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		outboxService = new OutboxService(port, messagePort);
+	}
+
+	@Test
+	void 에러가_없으면_아웃박스가_모두_true가_됨() throws JsonProcessingException {
+		// Arrange
+		List<OutboxCoupon> outboxCoupons = createOutboxCoupons();
+
+		when(port.load()).thenReturn(outboxCoupons);
+
+		// Act
+		outboxService.processOutboxMessage();
+
+		// Assert
+		verify(port, times(1)).saveAll(any());
+		assertAllOutboxCouponsDelivered(outboxCoupons);
+	}
+
+	@Test
+	void processOutboxMessage_예외발생시_트랜잭션_롤백() throws JsonProcessingException {
+		// Arrange
+		ParticipationDomain participationDomain = new ParticipationDomain(UUID.randomUUID().toString(),
+			UUID.randomUUID().toString());
+		OutboxCoupon outboxCoupon = new OutboxCoupon(mapper.writeValueAsString(participationDomain), false);
+		List<OutboxCoupon> outboxCoupons = List.of(outboxCoupon);
+
+		when(port.load()).thenReturn(outboxCoupons);
+		doThrow(new RuntimeException("메시지 전송 중 오류 발생")).when(messagePort).sendCouponMessage(
+			eq(TopicConfig.COUPON_TOPIC),
+			any(CouponMessageCommand.class)
+		);
+
+		// Act & Assert
+		assertThrows(RuntimeException.class, () -> outboxService.processOutboxMessage());
+
+		// Verify that saveAll was never called due to rollback
+		verify(port, never()).saveAll(any());
+		assertFalse(outboxCoupon.isDelivered(), "OutboxCoupon should not be marked as delivered due to rollback");
+	}
+
+	private List<OutboxCoupon> createOutboxCoupons() throws JsonProcessingException {
+		ParticipationDomain domain1 = new ParticipationDomain(UUID.randomUUID().toString(),
+			UUID.randomUUID().toString());
+		ParticipationDomain domain2 = new ParticipationDomain(UUID.randomUUID().toString(),
+			UUID.randomUUID().toString());
+
+		OutboxCoupon coupon1 = new OutboxCoupon(mapper.writeValueAsString(domain1), false);
+		OutboxCoupon coupon2 = new OutboxCoupon(mapper.writeValueAsString(domain2), true);
+
+		return List.of(coupon1, coupon2);
+	}
+
+	private void assertAllOutboxCouponsDelivered(List<OutboxCoupon> outboxCoupons) {
+		outboxCoupons.forEach(coupon -> assertTrue(coupon.isDelivered(), "OutboxCoupon should be delivered"));
+	}
+}

--- a/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/CronQueueServiceTest.java
+++ b/timeDeal/src/test/java/com/bjcareer/stockservice/timeDeal/service/CronQueueServiceTest.java
@@ -1,73 +1,64 @@
 package com.bjcareer.stockservice.timeDeal.service;
 
+import static org.mockito.Mockito.*;
+
 import java.util.UUID;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.redisson.api.RScoredSortedSet;
-import org.redisson.api.RedissonClient;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.bjcareer.stockservice.timeDeal.application.ports.TimeDealService;
+import com.bjcareer.stockservice.timeDeal.application.ports.out.OutboxCouponPort;
 import com.bjcareer.stockservice.timeDeal.domain.ParticipationDomain;
 import com.bjcareer.stockservice.timeDeal.domain.redis.Redis;
 import com.bjcareer.stockservice.timeDeal.domain.redis.RedisQueue;
-import com.bjcareer.stockservice.timeDeal.repository.EventRepository;
-import com.bjcareer.stockservice.timeDeal.service.out.MessagePort;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class CronQueueServiceTest {
-	public static final String TEST_KEY = TimeDealService.REDIS_QUEUE_NAME + "1";
-	public static final String TEST_PARTICIPANT = TimeDealService.REDIS_PARTICIPANT_SET + "1";
+	private Long eventId = 1L;
+	public String TEST_KEY = TimeDealService.REDIS_QUEUE_NAME + eventId;
+	public String TEST_PARTICIPANT = TimeDealService.REDIS_PARTICIPANT_SET;
 
-	@Autowired
+	@Mock
 	private TimeDealService timeDealService;
 
-	@Autowired
+	@Mock
 	private RedisQueue redisQueue;
 
-	@Autowired
+	@Mock
 	private Redis redis;
 
-	@Autowired
+	@Mock
+	private OutboxCouponPort couponPort;
+
+	@InjectMocks
 	private CronQueueService cronQueueService;
-
-	@Autowired
-	private MessagePort messagePort;
-
-	@Autowired
-	private RedissonClient client;
-
-	@Autowired
-	private EventRepository eventRepository;
-
 
 	@BeforeEach
 	void setUp() {
-		cronQueueService = new CronQueueService(redisQueue, redis, timeDealService, messagePort);
+		cronQueueService = new CronQueueService(redisQueue, redis, timeDealService, couponPort);
 	}
-
-	@AfterEach
-	void tearDown() {
-		client.getScoredSortedSet(TEST_KEY).clear();
-		client.getSet(TEST_PARTICIPANT).clear();
-	}
-
 
 	@Test
-	@Transactional
 	void 처음_신청한_유저인_경우_쿠폰을_발급_받을_수_있어야_함(){
-		String clientId = "1";
-		ParticipationDomain participationDomain = new ParticipationDomain(clientId, UUID.randomUUID().toString());
-		redisQueue.addParticipation(TEST_KEY, TEST_PARTICIPANT, participationDomain);
+		String clientId = UUID.randomUUID().toString();
+		String sessionId = UUID.randomUUID().toString();
+
+		ParticipationDomain participationDomain = new ParticipationDomain(clientId, sessionId);
+
+		when(redis.getSingleKeyUsingScan(TimeDealService.REDIS_QUEUE_NAME + "*")).thenReturn(TEST_KEY);
+		when(redisQueue.getClientInfoUsingBatch(TEST_KEY)).thenReturn(participationDomain).thenReturn(null);
+		doNothing().when(timeDealService).validateEventParticipant(any(), any());
+		when(timeDealService.updateDeliveryEventCoupon(1L, 1)).thenReturn(0);
+
 		cronQueueService.processParticipationQueue();
 
-		RScoredSortedSet<Object> scoredSortedSet = client.getScoredSortedSet(TEST_KEY);
-		Assertions.assertEquals(0, scoredSortedSet.size());
-		Assertions.assertEquals(0, client.getSet(TEST_PARTICIPANT).size());
+		verify(couponPort, times(1)).saveAll(any());
+		verify(timeDealService, times(1)).bulkGenerateCoupon(any(), any());
+		verify(redisQueue, times(1)).removeParticipation(any());
 	}
 }


### PR DESCRIPTION
## 💡 요약 (Summary)
아웃박스 릴레이 서비스 구현

## 📝 작업 내용 (What was changed)
- [x] 3초 마다 아웃박스 테이블에서 전송이 안된 메세지를 쿼리 후 카프카로 메세지 전송

## 🔗 관련 이슈 (Related Issue)
#47 

## 📊 변경 이유 (Reason for changes)
트랜잭션을 묶어주기 위해서 At-Least Once Delivery 방식을 사용함

## 🧪 테스트 (Test)
- [x] 에러가_없으면_아웃박스가_모두_true가_됨
- [x] 에러가_발생하면_트랜잭션으로_메세지가_모두_rollback
