### PR TITLE
[fix] Fix the bug

### DIFF
--- a/search/src/main/java/com/bjcareer/search/domain/gpt/GTPNewsDomain.java
+++ b/search/src/main/java/com/bjcareer/search/domain/gpt/GTPNewsDomain.java
@@ -31,10 +31,19 @@ public class GTPNewsDomain {
 		this.themas = themas;
 		this.nextReason = nextReason;
 
+		parseLocalDate(next);
+	}
+
+	private void parseLocalDate(String next) {
 		if (next == null || next.isEmpty()) {
 			this.next = Optional.empty();
 		} else {
-			this.next = Optional.of(LocalDate.parse(next));
+			try {
+				this.next = Optional.of(LocalDate.parse(next));
+			}catch (Exception e) {
+				log.error("Failed to parse date: {}", next);
+				this.next = Optional.empty();
+			}
 		}
 	}
 

--- a/search/src/main/java/com/bjcareer/search/out/persistence/repository/thema/Query.java
+++ b/search/src/main/java/com/bjcareer/search/out/persistence/repository/thema/Query.java
@@ -1,6 +1,6 @@
 package com.bjcareer.search.out.persistence.repository.thema;
 
 public class Query {
-	public static final String findThemaByName = "SELECT t FROM Thema t where t.themaInfo.name = :thema";
+	public static final String findThemaByName = "SELECT t FROM Thema t where t.themaInfo.name = :thema and t.stock.name = :stockName";
 	public static final String findThemaInfoByName = "SELECT t FROM Thema t where t.themaInfo.name = :thema";
 }

--- a/search/src/test/java/com/bjcareer/search/application/information/NewsServiceTest.java
+++ b/search/src/test/java/com/bjcareer/search/application/information/NewsServiceTest.java
@@ -116,7 +116,7 @@ class NewsServiceTest {
 		when(stockRepositoryPort.findByName(anyString())).thenReturn(Optional.of(stock));
 		when(stockChartRepositoryPort.loadStockChart(stock.getCode())).thenReturn(Optional.of(stockChart));
 		when(loadNewsPort.fetchNews(any())).thenReturn(List.of(news));
-		when(gptAPIPort.findStockRaiseReason(anyString(), anyString(), anyString(), any())).thenReturn(
+		when(gptAPIPort.findStockRaiseReason(anyString(), anyString(), any())).thenReturn(
 			Optional.of(gtpNewsDomain));
 
 		List<GTPNewsDomain> raiseReasonThatDate = newsService.findRaiseReasonThatDate(stockName, date);


### PR DESCRIPTION
## 💡 요약 (Summary)
orElse을 orElseGet으로 변경
그 이유는 orElse의 경우에는 기본 값을 돌려주기 위해서 값이 있건 없건 항상 뒤의 함수를 실행한다. 하지만 orElseGet은 값이 없을 때만 불린다.

## 📝 작업 내용 (What was changed)
- [ ] 문제가 되는 코드를 orElseGet으로 수정

## 🔗 관련 이슈 (Related Issue)
#96 

## 📊 변경 이유 (Reason for changes)
[참고 ](https://kdhyo98.tistory.com/40)
