### PR TITLE
[fix] Add order

### DIFF
--- a/search/src/main/java/com/bjcareer/search/out/persistence/stock/Query.java
+++ b/search/src/main/java/com/bjcareer/search/out/persistence/stock/Query.java
@@ -5,5 +5,5 @@ public class Query {
 	public static final String FIND_STOCK_BY_NAME = "SELECT s FROM Stock s WHERE s.name = :name";
 	public static final String FIND_ALL = "SELECT s FROM Stock s";
 
-	public static final String FILTER_STOCK_BY_KEYWORD = "SELECT s FROM Stock s LEFT JOIN FETCH s.themas t LEFT JOIN FETCH t.themaInfo WHERE s.name LIKE :keyword";
+	public static final String FILTER_STOCK_BY_KEYWORD = "SELECT s FROM Stock s LEFT JOIN FETCH s.themas t LEFT JOIN FETCH t.themaInfo WHERE s.name LIKE :keyword ORDER BY s.name";
 }

--- a/search/src/main/resources/application.yaml
+++ b/search/src/main/resources/application.yaml
@@ -41,8 +41,6 @@ server:
       force: true
       enabled: true
 
-  port: 8090
-
 management:
   endpoints:
     web:
@@ -76,6 +74,7 @@ GPT:
 
 python-search:
   address: http://${PYTHON_PUBLIC_SEARCH_SERVER_ADDRESS}:${PYTHON_SEARCH_SERVER_PORT}
+
 analyze-search:
-  address: http://localhost:8080
+  address: http://${ANALYZE_PUBLIC_SERVER_ADDRESS}:8080
 


### PR DESCRIPTION
## 🐞 버그 설명
사용자의 추천 검색어가 뒤죽박죽 오는 경우가 발생함 예를들면 동양을 입력하면 동양이 최상단 그 이후에 동양우가 와야 했지만 동양고속 동양 동양우 이런 식으로 보여짐

## 🐞 스크린샷 
<img width="458" alt="스크린샷 2024-12-09 오후 4 26 22" src="https://github.com/user-attachments/assets/10c67334-364b-444a-a13d-4e5ff452cf47">


## 🐞 해결방법
정렬조건을 추가함 